### PR TITLE
Fix atena online pedido

### DIFF
--- a/etls/raw/atena/online-pedido.py
+++ b/etls/raw/atena/online-pedido.py
@@ -27,7 +27,7 @@ schema = json.loads('{"type":"struct","fields":[{"name":"clientid","type":"integ
 # In[24]:
 
 
-sdf = ss.readStream.option("delimiter", "|").option("header", "true").csv(TRANSIENT_BUCKET, schema=StructType.fromJson(schema))
+sdf = ss.readStream.option("delimiter", ";").option("header", "false").csv(TRANSIENT_BUCKET, schema=StructType.fromJson(schema))
 
 # In[25]:
 


### PR DESCRIPTION
- Alterado delimitador que sempre foi ponte e vírgula, mas estava codificado com pipe
- Configurado header para false, que representa a realidade dos arquivos importados.